### PR TITLE
Simplify output from @openstack list 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pylint>=1.7
 python-novaclient>=7.1.0
 yas>=0.0.5
 Jinja2>=2.9.5
+openstacksdk==0.9.14

--- a/yas_openstack/server_list_handler.py
+++ b/yas_openstack/server_list_handler.py
@@ -95,10 +95,13 @@ class OpenStackServerListHandler(OpenStackHandler):
             # Add empty owner to remove from output
             metadata['owner'] = None
 
-        fields = [dict(title=key, value=server['metadata'][key], short=True)
-                  for key in server['metadata'] if not key in metadata and server['metadata'][key]]
-        fields.append(dict(title='addresses', value=', '.join(addresses), short=len(addresses) == 1))
-        fields.append(dict(title='id', value=server['id'], short=False))
+        if 'verbose' in metadata:
+            fields = [dict(title=key, value=server['metadata'][key], short=True)
+                      for key in server['metadata'] if not key in metadata and server['metadata'][key]]
+            fields.append(dict(title='addresses', value=', '.join(addresses), short=len(addresses) == 1))
+            fields.append(dict(title='id', value=server['id'], short=False))
+        else:
+            fields = []
 
         return dict(
             title=f"{server['name']}.{self.config.domain}",

--- a/yas_openstack/server_list_handler.py
+++ b/yas_openstack/server_list_handler.py
@@ -40,11 +40,13 @@ class OpenStackServerListHandler(OpenStackHandler):
                 raw_search_opts=raw_search_opts if raw_search_opts or raw_metadata else raw_default_search_opts)
 
         servers = self.server_manager.findall(**search_opts)
+        verbose = 'verbose' in data['text'].split(' ')
 
         attachments = [
             self.parse_server_to_attachment(
                 server.to_dict(),
-                search_opts['metadata'])
+                search_opts['metadata'],
+                verbose)
             for server in servers
         ]
 
@@ -58,7 +60,7 @@ class OpenStackServerListHandler(OpenStackHandler):
                       reply_broadcast=True,
                       attachments=attachments)
 
-    def parse_server_to_attachment(self, server, metadata):
+    def parse_server_to_attachment(self, server, metadata, verbose):
 
         self.log('DEBUG', f"Parsing server:\n{pformat(server)}")
         addresses = [interface['addr']
@@ -95,7 +97,7 @@ class OpenStackServerListHandler(OpenStackHandler):
             # Add empty owner to remove from output
             metadata['owner'] = None
 
-        if 'verbose' in metadata:
+        if verbose:
             fields = [dict(title=key, value=server['metadata'][key], short=True)
                       for key in server['metadata'] if not key in metadata and server['metadata'][key]]
             fields.append(dict(title='addresses', value=', '.join(addresses), short=len(addresses) == 1))


### PR DESCRIPTION
## Summary

Fixes: https://refinery29.atlassian.net/browse/HD-2614

PR wraps part of the `server_list_handler`'s response in a conditional. In specific, it hides `fields` unless the user includes "verbose" in her command. This makes the default response more compact.

**_New default response:_**

![screen shot 2017-06-22 at 3 50 54 pm](https://user-images.githubusercontent.com/2222416/27453344-16dd9770-5764-11e7-96d4-49fb28bdfc4f.png)

_New "verbose" option:_
![screen shot 2017-06-22 at 3 51 09 pm](https://user-images.githubusercontent.com/2222416/27453346-18dce0e4-5764-11e7-8aa5-5c98cc30f97d.png)


**## Testing**

I created a test bot, cw-tester. You may @ mention cw-tester and ask it to `list`, `list verbose`, `list all`, and `list all verbose`.