### PR TITLE
Make YasOpenstack compatible with refactored yas and expose help

### DIFF
--- a/yas_openstack/openstack_handler.py
+++ b/yas_openstack/openstack_handler.py
@@ -3,15 +3,14 @@ from yas import RegexHandler
 from yas_openstack.server import ServerManager
 from yas_openstack.yaml_file_config import YamlConfiguration
 
-
 CONFIG = YamlConfiguration()
 
 class OpenStackHandler(RegexHandler):
 
     SEARCH_OPTS_REGEX=r'[\w,_=:\.-]+'
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, regexp_string, bot):
+        super().__init__(regexp_string, bot)
         self.server_manager = ServerManager()
         self.matches = {}
         self.config = CONFIG

--- a/yas_openstack/server_create_handler.py
+++ b/yas_openstack/server_create_handler.py
@@ -23,10 +23,8 @@ def _parse_meta(meta_string):
     return meta_dict
 
 class OpenStackServerCreateHandler(OpenStackHandler):
-    """Call `launch <name>` to launch an OpenStack instance named `<name>`.
-    Aliases: `create` and `start`.
-    """
-    triggers = ['launch']
+    """Call `launch <name>` to launch an OpenStack instance named `<name>`."""
+    triggers = ['launch', 'create', 'start']
 
     def __init__(self, bot):
         super().__init__(r'(re)?(?:launch|start|create) ([-\w]+)'

--- a/yas_openstack/server_create_handler.py
+++ b/yas_openstack/server_create_handler.py
@@ -23,7 +23,7 @@ def _parse_meta(meta_string):
     return meta_dict
 
 class OpenStackServerCreateHandler(OpenStackHandler):
-    """Call `launch <name>` to launch an OpenStack instance named `<name>`."""
+    """Launches an OpenStack instance. Takes a single argument: the desired name."""
     triggers = ['launch', 'create', 'start']
 
     def __init__(self, bot):

--- a/yas_openstack/server_create_handler.py
+++ b/yas_openstack/server_create_handler.py
@@ -23,8 +23,10 @@ def _parse_meta(meta_string):
     return meta_dict
 
 class OpenStackServerCreateHandler(OpenStackHandler):
-    """Launches an OpenStack instance. Takes a single argument: the desired name."""
-    triggers = ['launch', 'create', 'start']
+    """Launches an OpenStack instance.
+    Takes a single argument: the desired name.
+    """
+    triggers = ['create', 'launch', 'start']
 
     def __init__(self, bot):
         super().__init__(r'(re)?(?:launch|start|create) ([-\w]+)'

--- a/yas_openstack/server_create_handler.py
+++ b/yas_openstack/server_create_handler.py
@@ -23,15 +23,19 @@ def _parse_meta(meta_string):
     return meta_dict
 
 class OpenStackServerCreateHandler(OpenStackHandler):
+    """Call `launch <name>` to launch an OpenStack instance named `<name>`.
+    Aliases: `create` and `start`.
+    """
+    triggers = ['launch']
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, bot):
         super().__init__(r'(re)?(?:launch|start|create) ([-\w]+)'
                          r'(?: on ([-\w]+:?[-\w/\.]+))?'
                          r'(?: meta(?:data)? (' + self.SEARCH_OPTS_REGEX + '))?'
                          r'(?: from ([-:/\w]+))?'
                          r'(?: using ([-:/\w]+))?',
-                         *args, **kwargs)
-        self.log('DEBUG', f'Initializing OpenStack server create handler with defaults:\n{self.config.__dict__}')
+                         bot)
+        self.bot.log.debug(f'Initializing OpenStack server create handler with defaults:\n{self.bot.config.__dict__}')
         self.template = self.get_userdata_template()
 
     def get_userdata_template(self):
@@ -48,7 +52,7 @@ class OpenStackServerCreateHandler(OpenStackHandler):
 
     def handle(self, data, reply):
         recreate, name, branch, meta_string, image, neptune_branch = self.current_match.groups()
-        self.log('INFO', f"Received request for {name} on {branch} from {image}")
+        self.bot.log.info(f"Received request for {name} on {branch} from {image}")
 
         if recreate == 're':
 
@@ -70,7 +74,7 @@ class OpenStackServerCreateHandler(OpenStackHandler):
 
         meta = _parse_meta(meta_string)
 
-        creator_info = self._retrieve_user_info(data.get('user', ''))
+        creator_info = self.bot.retrieve_user_info(data.get('user', ''))
 
         if creator_info and 'user' in creator_info:
             meta['owner'] = creator_info['user']['name']
@@ -98,4 +102,4 @@ class OpenStackServerCreateHandler(OpenStackHandler):
             raise forbidden
 
         reply(f'Requested creation of {name} with id {server.id}')
-        self.log('DEBUG', f'Created used userdata:\n{userdata}')
+        self.bot.log.debug(f'Created used userdata:\n{userdata}')

--- a/yas_openstack/server_delete_handler.py
+++ b/yas_openstack/server_delete_handler.py
@@ -9,7 +9,7 @@ class OpenStackServerDeleteHandler(OpenStackHandler):
     triggers = ['drop']
 
     def __init__(self, bot):
-        super().__init__(r'^(?:delete|drop|terminate|bust a cap in|pop a cap in)?'
+        super().__init__(r'(?:delete|drop|terminate|bust a cap in|pop a cap in)'
                          r'(?: search_opts (' + self.SEARCH_OPTS_REGEX + '))?'
                          r'(?: meta(?:data)? (!?' + self.SEARCH_OPTS_REGEX + '))?'
                          r'(?: ([- \w,_=]+))?',

--- a/yas_openstack/server_delete_handler.py
+++ b/yas_openstack/server_delete_handler.py
@@ -3,10 +3,11 @@ from yas_openstack.server import ServersFoundException
 
 
 class OpenStackServerDeleteHandler(OpenStackHandler):
-    """Drops an OpenStack instance. Takes a single argument: the name(s) of the instance(s).
+    """Drops an OpenStack instance.
+    Takes a single argument: the name(s) of the instance(s).
     Use spaces to separate instances if deleting more than one.
     """
-    triggers = ['drop', 'delete', 'terminate', 'bust a cap in', 'pop a cap in']
+    triggers = ['delete', 'drop', 'terminate', 'bust a cap in', 'pop a cap in']
 
     def __init__(self, bot):
         super().__init__(r'(?:delete|drop|terminate|bust a cap in|pop a cap in)'

--- a/yas_openstack/server_delete_handler.py
+++ b/yas_openstack/server_delete_handler.py
@@ -3,17 +3,20 @@ from yas_openstack.server import ServersFoundException
 
 
 class OpenStackServerDeleteHandler(OpenStackHandler):
+    """Call `drop <name>` to delete the OpenStack instance named <name>.
+    Aliases: `delete`, `terminate`, and `bust a cap in`.
+    """
+    triggers = ['drop']
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(r'(?:delete|drop|terminate|bust a cap in|pop a cap in)'
+    def __init__(self, bot):
+        super().__init__(r'^(?:delete|drop|terminate|bust a cap in|pop a cap in)?'
                          r'(?: search_opts (' + self.SEARCH_OPTS_REGEX + '))?'
                          r'(?: meta(?:data)? (!?' + self.SEARCH_OPTS_REGEX + '))?'
                          r'(?: ([- \w,_=]+))?',
-                         *args, **kwargs)
+                         bot)
 
     def handle(self, _, reply):
         raw_search_opts, raw_metadata, names = self.current_match.groups()
-
         try:
             webhook = self.config.webhooks['server']['delete']
         except KeyError:

--- a/yas_openstack/server_delete_handler.py
+++ b/yas_openstack/server_delete_handler.py
@@ -3,7 +3,9 @@ from yas_openstack.server import ServersFoundException
 
 
 class OpenStackServerDeleteHandler(OpenStackHandler):
-    """Call `drop <name>` to delete the OpenStack instance named <name>."""
+    """Drops an OpenStack instance. Takes a single argument: the name(s) of the instance(s).
+    Use spaces to separate instances if deleting more than one.
+    """
     triggers = ['drop', 'delete', 'terminate', 'bust a cap in', 'pop a cap in']
 
     def __init__(self, bot):

--- a/yas_openstack/server_delete_handler.py
+++ b/yas_openstack/server_delete_handler.py
@@ -3,10 +3,8 @@ from yas_openstack.server import ServersFoundException
 
 
 class OpenStackServerDeleteHandler(OpenStackHandler):
-    """Call `drop <name>` to delete the OpenStack instance named <name>.
-    Aliases: `delete`, `terminate`, and `bust a cap in`.
-    """
-    triggers = ['drop']
+    """Call `drop <name>` to delete the OpenStack instance named <name>."""
+    triggers = ['drop', 'delete', 'terminate', 'bust a cap in', 'pop a cap in']
 
     def __init__(self, bot):
         super().__init__(r'(?:delete|drop|terminate|bust a cap in|pop a cap in)'

--- a/yas_openstack/server_list_handler.py
+++ b/yas_openstack/server_list_handler.py
@@ -12,7 +12,7 @@ class OpenStackServerListHandler(OpenStackHandler):
     triggers = ['list']
 
     def __init__(self, bot):
-        super().__init__(r'^(?:list)(?: +(all))?'
+        super().__init__(r'(?:list)(?: +(all))?'
                          r'(?: search_opts (' + self.SEARCH_OPTS_REGEX + '))?'
                          r'(?: meta(?:data)? (!?' + self.SEARCH_OPTS_REGEX + '))?',
                          bot)

--- a/yas_openstack/server_list_handler.py
+++ b/yas_openstack/server_list_handler.py
@@ -6,7 +6,8 @@ from yas_openstack.openstack_handler import OpenStackHandler
 
 
 class OpenStackServerListHandler(OpenStackHandler):
-    """Call `list` to list your instances; `list all` to list everyone's.
+    """Lists your OpenStack instances.
+    Use `list all` to get a list of everyone's' instances.
     Add `verbose` to get more information like IP, status, and owner.
     """
     triggers = ['list']


### PR DESCRIPTION

## Summary 

Relates to [INF-1234](https://refinery29.atlassian.net/browse/INF-1234) and [INF-1158](https://refinery29.atlassian.net/browse/INF-1158). 

Depends on (both merged): 
https://github.com/refinery29/yas/pull/2
https://github.com/refinery29/yas/pull/1


@schlueter refactored `yas`, adding a `HandlerManager` so that handlers can be aware of other handlers. This means we can have a `help_handler` that knows about the other handlers and can document each of them.

This PR makes `YasOpenstack` compatible with the refactored version of `yas`. 

## Testing

- [x] `@cw-tester id` behaves as expected.
- [x] `@cw-tester launch` successfully launches an instance.
- [x] `@cw-tester drop` and `list` and `list all` behave as expected.
- [x] `@cw-tester help` provides a list of available commands.
- [x] `@cw-tester help` works for `launch`, `drop`, `list`, and `id`.
- [x] `@cw-tester` bot does not respond unless you're talking to it.