### PR TITLE
[WIP] Ansible playbook for YasOpenstack

### DIFF
--- a/playbooks/main.yml
+++ b/playbooks/main.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  gather_facts: yes
+  become: yes
+  roles: [ yas-openstack ]

--- a/playbooks/roles/pyenv/defaults/main.yml
+++ b/playbooks/roles/pyenv/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+users: [ ubuntu ]
+pythons: [ 3.6.0 ]

--- a/playbooks/roles/pyenv/tasks/main.yml
+++ b/playbooks/roles/pyenv/tasks/main.yml
@@ -1,0 +1,84 @@
+---
+- name: Create pyenv group
+  group: name=pyenv system=yes
+
+- name: Give pyenv group access to the pyenv directory
+  file:
+    path=/usr/local/lib/pyenv
+    group=pyenv
+    recurse=yes
+    mode=2775
+    state=directory
+
+- name: Clone pyenv
+  git:
+    repo=https://github.com/yyuu/pyenv.git
+    dest=/usr/local/lib/pyenv
+    update=no
+
+- name: Add users to pyenv group
+  user:
+    name={{ item }}
+    append=yes
+    groups=pyenv
+  with_items: "{{ users }}"
+
+- name: Add PYENV_ROOT to global environment
+  lineinfile:
+    line=PYENV_ROOT=/usr/local/lib/pyenv
+    insertbefore=PATH=
+    dest=/etc/environment
+
+- name: Update global PATH with pyenv bin
+  lineinfile:
+    regexp='(^PATH=")(?!/usr/local/lib/pyenv/bin:)(.*)'
+    line='\1/usr/local/lib/pyenv/bin:\2'
+    backrefs=yes
+    dest=/etc/environment
+
+- name: Make pyenv intialize on login
+  copy:
+    dest=/etc/profile.d/pyenv.sh
+    content='eval "$(pyenv init -)"'
+
+- name: Install some common deps
+  apt:
+    state=latest
+    pkg={{ item }}
+    update_cache=yes
+    cache_valid_time=1800
+  with_items:
+    - zlib1g-dev
+    - openssl
+    - libbz2-dev
+    - libreadline6-dev
+    - libssl-dev
+    - libsqlite3-dev
+    - libsystemd-dev
+    - build-essential
+
+- name: Get existing pythons
+  command: ls /usr/local/lib/pyenv/versions
+  register: versions
+  changed_when: no
+  ignore_errors: yes
+
+- name: Install some pythons
+  command: /usr/local/lib/pyenv/bin/pyenv install {{ item }}
+  environment:
+    PYENV_ROOT: /usr/local/lib/pyenv
+  with_items: "{{ pythons }}"
+  when: not item in versions.stdout_lines | map('trim')
+
+- name: Set 3.6.0 as default python
+  copy:
+    dest=/usr/local/lib/pyenv/version
+    content=3.6.0
+
+- name: Ensure the pyenv dir has correct permissions
+  file:
+    path=/usr/local/lib/pyenv
+    group=pyenv
+    recurse=yes
+    mode=2775
+    state=directory

--- a/playbooks/roles/yas-openstack/defaults/main.yml
+++ b/playbooks/roles/yas-openstack/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# defaults file for yas-openstack
+local_repository: '/srv/YasOpenstack'

--- a/playbooks/roles/yas-openstack/defaults/main.yml
+++ b/playbooks/roles/yas-openstack/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-# defaults file for yas-openstack
 local_repository: '/srv/YasOpenstack'

--- a/playbooks/roles/yas-openstack/handlers/main.yml
+++ b/playbooks/roles/yas-openstack/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for yas-openstack

--- a/playbooks/roles/yas-openstack/handlers/main.yml
+++ b/playbooks/roles/yas-openstack/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for yas-openstack

--- a/playbooks/roles/yas-openstack/meta/main.yml
+++ b/playbooks/roles/yas-openstack/meta/main.yml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: yas
+    src: https://github.com/refinery29/yas.git
+    scm: git

--- a/playbooks/roles/yas-openstack/tasks/main.yml
+++ b/playbooks/roles/yas-openstack/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# tasks file for yas-openstack
+- name: clone YasOpenstack repository
+  git:
+    repo=https://github.com/refinery29/YasOpenstack.git
+    dest={{ local_repository }}
+    accept_hostkey=yes
+
+- name: install YasOpenstack
+  pip:
+    name={{ local_repository }}
+    state=present

--- a/playbooks/roles/yas/defaults/main.yml
+++ b/playbooks/roles/yas/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+local_repository: /srv/yas

--- a/playbooks/roles/yas/meta/main.yml
+++ b/playbooks/roles/yas/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - pyenv

--- a/playbooks/roles/yas/tasks/main.yml
+++ b/playbooks/roles/yas/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- name: Clone yas repo
+  git:
+    repo=https://github.com/schlueter/yas.git
+    dest={{ local_repository }}
+    update=no
+    accept_hostkey=yes
+
+- name: Install yas
+  pip:
+    name={{ local_repository }}
+    state=latest
+
+- name: Set slack_app_token if provided
+  lineinfile:
+    dest: /usr/local/lib/pyenv/versions/3.6.0/etc/yas/yas.yml
+    regexp: '^slack_app_token: '
+    line: "slack_app_token: {{ slack_app_token }}"
+  when: slack_app_token is defined
+
+- name: Set slack_app_name if provided
+  lineinfile:
+    dest: /usr/local/lib/pyenv/versions/3.6.0/etc/yas/yas.yml
+    regexp: '^slack_app_name: '
+    line: "bot_name: {{ slack_app_name }}"
+  when: slack_app_name is defined
+
+- name: Set log_level if provided
+  lineinfile:
+    dest: /usr/local/lib/pyenv/versions/3.6.0/etc/yas/yas.yml
+    regexp: '^log_level:'
+    line: 'log_level: {{ log_level }}'
+  when: log_level is defined
+
+- name: Install yas systemd service
+  copy:
+    src={{ local_repository }}/yas.service
+    remote_src=yes
+    dest=/etc/systemd/system/yas.service
+  when: ansible_service_mgr == 'systemd'
+
+- name: Activate yas systemd service
+  systemd:
+    name=yas
+    daemon_reload=yes
+    enabled=yes
+    state=started
+  when: ansible_service_mgr == 'systemd'

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+- name: yas
+  src: https://github.com/refinery29/yas.git
+  scm: git


### PR DESCRIPTION
## SUMMARY

**Fixes**
https://refinery29.atlassian.net/browse/INF-1300

**Releases** 
https://refinery29.atlassian.net/browse/INF-1234
https://refinery29.atlassian.net/browse/INF-1406

## TODO

- [x] Using `ansible-galaxy` generate scaffolding for new role `yas-openstack`.
- [x] Using `ansible-galaxy` import roles for `yas` and `pyenv` from the yas repository.
- [x] Start fleshing out `yas-openstack` role: make `yas` a dependency, clone the YasOpenstack repository, and install YasOpenstack.

Figure out...

- [ ] Are the Slackbot credentials being set? The `yas` role does some of that.
- [ ] Does it matter where the `yas` and `YasOpenstack` repositories are cloned to? Right now `yas` is ending up in `/tmp/yas` and `YasOpenstack` is in `/srv/YasOpenStack`. 

## Testing

TODO