### PR TITLE
Validate hostname is not numbers only

### DIFF
--- a/yas_openstack/server_create_handler.py
+++ b/yas_openstack/server_create_handler.py
@@ -54,6 +54,9 @@ class OpenStackServerCreateHandler(OpenStackHandler):
         recreate, name, branch, meta_string, image, neptune_branch = self.current_match.groups()
         self.bot.log.info(f"Received request for {name} on {branch} from {image}")
 
+        if name.isdigit():
+            reply(f'{name} is not a valid hostname. Numbers-only hostnames are not allowed.')
+
         if recreate == 're':
             try:
                 server = self.server_manager.find(name=f'^{name}$')


### PR DESCRIPTION
INF-1570: OpenStack doesn't handle number-only hostnames properly. Check before proceeding until we identify the root cause.