### PR TITLE
Update regex for launch to allow any non space char in branch names

### DIFF
--- a/yas_openstack/server_create_handler.py
+++ b/yas_openstack/server_create_handler.py
@@ -29,11 +29,11 @@ class OpenStackServerCreateHandler(OpenStackHandler):
     triggers = ['create', 'launch', 'start']
 
     def __init__(self, bot):
-        super().__init__(r'(re)?(?:launch|start|create) ([-\w]+)'
-                         r'(?: on ([-\w]+:?[-\w/\.]+))?'
+        super().__init__(r'(re)?(?:launch|start|create) ([-a-zA-Z0-9]+)'
+                         r'(?: on ([^\ ]+:?[^\ ]+))?'
                          r'(?: meta(?:data)? (' + self.SEARCH_OPTS_REGEX + '))?'
-                         r'(?: from ([-:/\w]+))?'
-                         r'(?: using ([-:/\w]+))?',
+                         r'(?: from ([^\ ]+))?'
+                         r'(?: using ([^\ ]+))?',
                          bot)
         self.bot.log.debug(f'Initializing OpenStack server create handler with defaults:\n{self.bot.config.__dict__}')
         self.template = self.get_userdata_template()


### PR DESCRIPTION
Currently if an instance is launched like `launch foobar using feature/a.b` only `feature/a` is passed as a param to using. This makes it so that any non space char is included in the branch name.