### PR TITLE
Revert "Either use the delete webhook or delete servers, not both"

### DIFF
--- a/yas_openstack/server.py
+++ b/yas_openstack/server.py
@@ -59,9 +59,8 @@ class ServerManager(Client):
             uri = webhook['url'] + '?' + encoded_query
             request = urllib.request.Request(uri, method='POST')
             urllib.request.urlopen(request)
-        else:
-            server = self.servers.get(server.id)
-            server.delete()
+        server = self.servers.get(server.id)
+        server.delete()
 
     def find(self, detailed=True, metadata=None, **kwargs):
         servers = self.findall(detailed=detailed, metadata=metadata, **kwargs)


### PR DESCRIPTION
Reverts refinery29/YasOpenstack#17

This broke relaunch because now, the webhook is called, and the new instance created almost simultaneously, so when the obliterate job gets around to deleting the instance, it can't because there are now two of them with the same name. We need to make this stuff act on the IDs instead of the names.